### PR TITLE
Fix throwing on invalid fingerprints

### DIFF
--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -99,6 +99,8 @@ Fingerprint.parse = function (fp, options) {
 		if (parts[0].toLowerCase() === 'md5')
 			parts = parts.slice(1);
 		parts = parts.join('');
+		if (parts.length % 2 !== 0)
+			throw (new FingerprintFormatError(fp));
 		/*JSSTYLED*/
 		var md5RE = /^[a-fA-F0-9]+$/;
 		if (!md5RE.test(parts))


### PR DESCRIPTION
This makes tests pass on current Node.js versions.

The test in question is https://github.com/joyent/node-sshpk/blob/v1.14.0/test/fingerprint.js#L117-L120 — it fails on Node.js 8 and 9 without this patch.

This is alternative approach to #41 (which just changes the test for some reason).