### PR TITLE
Add support for ed25519 private keys in pkcs8

### DIFF
--- a/bin/sshpk-conv
+++ b/bin/sshpk-conv
@@ -91,12 +91,12 @@ if (require.main === module) {
 		console.error('sshpk-conv: converts between SSH key formats\n');
 		console.error(help);
 		console.error('\navailable key formats:');
-		console.error('	 - pem, pkcs1	  eg id_rsa');
-		console.error('	 - ssh		  eg id_rsa.pub');
-		console.error('	 - pkcs8	  format you want for openssl');
-		console.error('	 - openssh	  like output of ssh-keygen -o');
-		console.error('	 - rfc4253	  raw OpenSSH wire format');
-		console.error('	 - dnssec	  dnssec-keygen format');
+		console.error('  - pem, pkcs1     eg id_rsa');
+		console.error('  - ssh            eg id_rsa.pub');
+		console.error('  - pkcs8          format you want for openssl');
+		console.error('  - openssh        like output of ssh-keygen -o');
+		console.error('  - rfc4253        raw OpenSSH wire format');
+		console.error('  - dnssec         dnssec-keygen format');
 		console.error('  - putty          PuTTY ppk format');
 		console.error('\navailable fingerprint formats:');
 		console.error('  - hex            colon-separated hex for SSH');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sshpk",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "A library for finding and using SSH public keys",
   "main": "lib/index.js",
   "scripts": {
@@ -49,8 +49,7 @@
     "ecc-jsbn": "~0.1.1",
     "bcrypt-pbkdf": "^1.0.0"
   },
-  "optionalDependencies": {
-  },
+  "optionalDependencies": {},
   "devDependencies": {
     "tape": "^3.5.0",
     "benchmark": "^1.0.0",

--- a/test/private-key.js
+++ b/test/private-key.js
@@ -127,6 +127,16 @@ test('PrivateKey load ed25519 key (w/ public curdle-pkix-05)', function (t) {
 	t.end();
 });
 
+test('PrivateKey convert ed25519 key from pkcs1 to pkcs8', function (t) {
+	var keyPem = fs.readFileSync(path.join(testDir, 'id_ed25519.pem'));
+	var key = sshpk.parsePrivateKey(keyPem, 'pem');
+	var newPem = key.toString('pkcs8');
+	var key2 = sshpk.parsePrivateKey(newPem, 'pem');
+	t.strictEqual(key.type, 'ed25519');
+	t.strictEqual(key.size, 256);
+	t.end();
+});
+
 test('PrivateKey invalid ed25519 key (not DER)', function (t) {
 	var keyPem = fs.readFileSync(path.join(testDir,
 	    'ed25519-invalid-ber.pem'));


### PR DESCRIPTION
Picking up the great work from @arekinath in #83. This PR is identical to #83 apart from one change to fix the mentioneed style issue mentioned in https://github.com/TritonDataCenter/node-sshpk/pull/83#discussion_r884351964.

Feel free to cherry-pick / rebase this into the initial PR if you prefer.

Make check passes for me with this change:
```
make check
deps/javascriptlint/build/install/jsl --nologo --nosummary --conf=tools/jsl.node.conf lib/key.js lib/dhe.js lib/fingerprint.js lib/formats/ssh-private.js lib/formats/pkcs1.js lib/formats/openssh-cert.js lib/formats/putty.js lib/formats/x509-pem.js lib/formats/pem.js lib/formats/x509.js lib/formats/ssh.js lib/formats/pkcs8.js lib/formats/auto.js lib/formats/dnssec.js lib/formats/rfc4253.js lib/ed-compat.js lib/ssh-buffer.js lib/certificate.js lib/index.js lib/signature.js lib/errors.js lib/algs.js lib/private-key.js lib/identity.js lib/utils.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/key.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/dhe.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/fingerprint.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/ssh-private.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/pkcs1.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/openssh-cert.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/putty.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/x509-pem.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/pem.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/x509.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/ssh.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/pkcs8.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/auto.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/dnssec.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/formats/rfc4253.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/ed-compat.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/ssh-buffer.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/certificate.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/index.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/signature.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/errors.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/algs.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/private-key.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/identity.js
/Users/teutat3s/Code/github.com/TritonDataCenter/node-sshpk/lib/utils.js
deps/jsstyle/jsstyle -f tools/jsstyle.conf lib/key.js lib/dhe.js lib/fingerprint.js lib/formats/ssh-private.js lib/formats/pkcs1.js lib/formats/openssh-cert.js lib/formats/putty.js lib/formats/x509-pem.js lib/formats/pem.js lib/formats/x509.js lib/formats/ssh.js lib/formats/pkcs8.js lib/formats/auto.js lib/formats/dnssec.js lib/formats/rfc4253.js lib/ed-compat.js lib/ssh-buffer.js lib/certificate.js lib/index.js lib/signature.js lib/errors.js lib/algs.js lib/private-key.js lib/identity.js lib/utils.js
check ok
```

Related to #81